### PR TITLE
fix: respect totalTimeout and do not retry if nextRetryDelay is <= 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,11 @@ function retryRequest(requestOpts, opts, callback) {
     });
     debug(`Next retry delay: ${nextRetryDelay}`);
 
+    if (nextRetryDelay <= 0) {
+      numNoResponseAttempts = opts.noResponseRetries + 1;
+      return
+    }
+    
     setTimeout(makeRequest, nextRetryDelay);
   }
 

--- a/index.js
+++ b/index.js
@@ -188,9 +188,9 @@ function retryRequest(requestOpts, opts, callback) {
 
     if (nextRetryDelay <= 0) {
       numNoResponseAttempts = opts.noResponseRetries + 1;
-      return
+      return;
     }
-    
+
     setTimeout(makeRequest, nextRetryDelay);
   }
 


### PR DESCRIPTION
I noticed an issue where `totalTimeout` is not being respected to end the retry cycle. It is possible for [this value](https://github.com/stephenplusplus/retry-request/blob/f06f6351bd1f4d635804fb1c77e14984f2c9b2e4/index.js#L250) to go negative which causes [setTimeout](https://github.com/stephenplusplus/retry-request/blob/f06f6351bd1f4d635804fb1c77e14984f2c9b2e4/index.js#L187) to default to executing immediately. 