### PR TITLE
chore: include standard lint configs, fix quotes

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,6 +5,7 @@ branchProtectionRules:
 - pattern: main
   isAdminEnforced: true
   requiredStatusCheckContexts:
+    - 'lint'
     - 'test (10)'
     - 'test (12)'
     - 'test (14)'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+**/node_modules
+**/coverage
+test/fixtures
+build/
+docs/
+protos/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module.exports = {
+  ...require('gts/.prettierrc.json')
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 declare module 'retry-request' {
+  // eslint-disable-next-line node/no-unpublished-import
   import * as request from 'request';
 
   namespace retryRequest {

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,22 +4,27 @@ declare module 'retry-request' {
   namespace retryRequest {
     function getNextRetryDelay(retryNumber: number): void;
     interface Options {
-      objectMode?: boolean,
-      request?: typeof request,
-      retries?: number,
-      noResponseRetries?: number,
-      currentRetryAttempt?: number,
-      maxRetryDelay?: number,
-      retryDelayMultiplier?: number,
-      totalTimeout?: number,
-      shouldRetryFn?: (response: request.RequestResponse) => boolean
+      objectMode?: boolean;
+      request?: typeof request;
+      retries?: number;
+      noResponseRetries?: number;
+      currentRetryAttempt?: number;
+      maxRetryDelay?: number;
+      retryDelayMultiplier?: number;
+      totalTimeout?: number;
+      shouldRetryFn?: (response: request.RequestResponse) => boolean;
     }
   }
 
-  function retryRequest(requestOpts: request.Options, opts: retryRequest.Options, callback?: request.RequestCallback)
-    : { abort: () => void };
-  function retryRequest(requestOpts: request.Options, callback?: request.RequestCallback)
-    : { abort: () => void };
+  function retryRequest(
+    requestOpts: request.Options,
+    opts: retryRequest.Options,
+    callback?: request.RequestCallback
+  ): {abort: () => void};
+  function retryRequest(
+    requestOpts: request.Options,
+    callback?: request.RequestCallback
+  ): {abort: () => void};
 
   export = retryRequest;
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var { PassThrough } = require('stream');
-var debug = require('debug')('retry-request');
-var extend = require('extend');
+const {PassThrough} = require('stream');
+const debug = require('debug')('retry-request');
+const extend = require('extend');
 
-var DEFAULTS = {
+const DEFAULTS = {
   objectMode: false,
   retries: 2,
 
@@ -13,7 +13,7 @@ var DEFAULTS = {
     delay greater than maxRetryDelay, retries should delay by maxRetryDelay
     seconds instead.
   */
-  maxRetryDelay: 64, 
+  maxRetryDelay: 64,
 
   /*
     The multiplier by which to increase the delay time between the completion of
@@ -33,7 +33,7 @@ var DEFAULTS = {
   noResponseRetries: 2,
   currentRetryAttempt: 0,
   shouldRetryFn: function (response) {
-    var retryRanges = [
+    const retryRanges = [
       // https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
       // 1xx - Retry (Informational, request still processing)
       // 2xx - Do not retry (Success)
@@ -43,30 +43,31 @@ var DEFAULTS = {
       // 5xx - Retry (Server errors)
       [100, 199],
       [429, 429],
-      [500, 599]
+      [500, 599],
     ];
 
-    var statusCode = response.statusCode;
+    const statusCode = response.statusCode;
     debug(`Response status: ${statusCode}`);
 
-    var range;
+    let range;
     while ((range = retryRanges.shift())) {
       if (statusCode >= range[0] && statusCode <= range[1]) {
         // Not a successful status or redirect.
         return true;
       }
     }
-  }
+  },
 };
 
 function retryRequest(requestOpts, opts, callback) {
-  var streamMode = typeof arguments[arguments.length - 1] !== 'function';
+  const streamMode = typeof arguments[arguments.length - 1] !== 'function';
 
   if (typeof opts === 'function') {
     callback = opts;
   }
 
-  var manualCurrentRetryAttemptWasSet = opts && typeof opts.currentRetryAttempt === 'number';
+  const manualCurrentRetryAttemptWasSet =
+    opts && typeof opts.currentRetryAttempt === 'number';
   opts = extend({}, DEFAULTS, opts);
 
   if (typeof opts.request === 'undefined') {
@@ -77,30 +78,30 @@ function retryRequest(requestOpts, opts, callback) {
     }
   }
 
-  var currentRetryAttempt = opts.currentRetryAttempt;
+  let currentRetryAttempt = opts.currentRetryAttempt;
 
-  var numNoResponseAttempts = 0;
-  var streamResponseHandled = false;
+  let numNoResponseAttempts = 0;
+  let streamResponseHandled = false;
 
-  var retryStream;
-  var requestStream;
-  var delayStream;
+  let retryStream;
+  let requestStream;
+  let delayStream;
 
-  var activeRequest;
-  var retryRequest = {
+  let activeRequest;
+  const retryRequest = {
     abort: function () {
       if (activeRequest && activeRequest.abort) {
         activeRequest.abort();
       }
-    }
+    },
   };
 
   if (streamMode) {
-    retryStream = new PassThrough({ objectMode: opts.objectMode });
+    retryStream = new PassThrough({objectMode: opts.objectMode});
     retryStream.abort = resetStreams;
   }
 
-  var timeOfFirstRequest = Date.now();
+  const timeOfFirstRequest = Date.now();
   if (currentRetryAttempt > 0) {
     retryAfterDelay(currentRetryAttempt);
   } else {
@@ -135,10 +136,10 @@ function retryRequest(requestOpts, opts, callback) {
     if (streamMode) {
       streamResponseHandled = false;
 
-      delayStream = new PassThrough({ objectMode: opts.objectMode });
+      delayStream = new PassThrough({objectMode: opts.objectMode});
       requestStream = opts.request(requestOpts);
 
-      setImmediate(function () {
+      setImmediate(() => {
         retryStream.emit('request');
       });
 
@@ -146,7 +147,7 @@ function retryRequest(requestOpts, opts, callback) {
         // gRPC via google-cloud-node can emit an `error` as well as a `response`
         // Whichever it emits, we run with-- we can't run with both. That's what
         // is up with the `streamResponseHandled` tracking.
-        .on('error', function (err) {
+        .on('error', err => {
           if (streamResponseHandled) {
             return;
           }
@@ -154,7 +155,7 @@ function retryRequest(requestOpts, opts, callback) {
           streamResponseHandled = true;
           onResponse(err);
         })
-        .on('response', function (resp, body) {
+        .on('response', (resp, body) => {
           if (streamResponseHandled) {
             return;
           }
@@ -175,7 +176,7 @@ function retryRequest(requestOpts, opts, callback) {
       resetStreams();
     }
 
-    var nextRetryDelay = getNextRetryDelay({
+    const nextRetryDelay = getNextRetryDelay({
       maxRetryDelay: opts.maxRetryDelay,
       retryDelayMultiplier: opts.retryDelayMultiplier,
       retryNumber: currentRetryAttempt,
@@ -211,8 +212,13 @@ function retryRequest(requestOpts, opts, callback) {
     // the very first request sent as the first "retry". It is only accurate
     // when a user provides their own "currentRetryAttempt" option at
     // instantiation.
-    var adjustedCurrentRetryAttempt = manualCurrentRetryAttemptWasSet ? currentRetryAttempt : currentRetryAttempt - 1;
-    if (adjustedCurrentRetryAttempt < opts.retries && opts.shouldRetryFn(response)) {
+    const adjustedCurrentRetryAttempt = manualCurrentRetryAttemptWasSet
+      ? currentRetryAttempt
+      : currentRetryAttempt - 1;
+    if (
+      adjustedCurrentRetryAttempt < opts.retries &&
+      opts.shouldRetryFn(response)
+    ) {
       retryAfterDelay(currentRetryAttempt);
       return;
     }
@@ -221,7 +227,7 @@ function retryRequest(requestOpts, opts, callback) {
     if (streamMode) {
       retryStream.emit('response', response);
       delayStream.pipe(retryStream);
-      requestStream.on('error', function (err) {
+      requestStream.on('error', err => {
         retryStream.destroy(err);
       });
     } else {
@@ -233,7 +239,7 @@ function retryRequest(requestOpts, opts, callback) {
 module.exports = retryRequest;
 
 function getNextRetryDelay(config) {
-  var {
+  const {
     maxRetryDelay,
     retryDelayMultiplier,
     retryNumber,
@@ -241,15 +247,21 @@ function getNextRetryDelay(config) {
     totalTimeout,
   } = config;
 
-  var maxRetryDelayMs = maxRetryDelay * 1000;
-  var totalTimeoutMs = totalTimeout * 1000;
+  const maxRetryDelayMs = maxRetryDelay * 1000;
+  const totalTimeoutMs = totalTimeout * 1000;
 
-  var jitter = Math.floor(Math.random() * 1000);
-  var calculatedNextRetryDelay = Math.pow(retryDelayMultiplier, retryNumber) * 1000 + jitter;
+  const jitter = Math.floor(Math.random() * 1000);
+  const calculatedNextRetryDelay =
+    Math.pow(retryDelayMultiplier, retryNumber) * 1000 + jitter;
 
-  var maxAllowableDelayMs = totalTimeoutMs - (Date.now() - timeOfFirstRequest);
+  const maxAllowableDelayMs =
+    totalTimeoutMs - (Date.now() - timeOfFirstRequest);
 
-  return Math.min(calculatedNextRetryDelay, maxAllowableDelayMs, maxRetryDelayMs);
+  return Math.min(
+    calculatedNextRetryDelay,
+    maxAllowableDelayMs,
+    maxRetryDelayMs
+  );
 }
 
 module.exports.getNextRetryDelay = getNextRetryDelay;

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ function retryRequest(requestOpts, opts, callback) {
 
   if (typeof opts.request === 'undefined') {
     try {
+      // eslint-disable-next-line node/no-unpublished-require
       opts.request = require('request');
     } catch (e) {
       throw new Error('A request library must be provided to retry-request.');

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "extend": "^3.0.2"
   },
   "devDependencies": {
+    "@types/request": "^2.48.8",
     "async": "^3.0.1",
     "gts": "^3.1.0",
     "lodash.range": "^3.2.0",

--- a/test.js
+++ b/test.js
@@ -1,156 +1,158 @@
 'use strict';
 
-var assert = require('assert');
-var async = require('async');
-var range = require('lodash.range');
-var { PassThrough } = require('stream');
+const assert = require('assert');
+const async = require('async');
+const range = require('lodash.range');
+const {describe, it, beforeEach} = require('mocha');
+const {PassThrough} = require('stream');
 
-var retryRequest = require('./index.js');
+const retryRequest = require('./index.js');
 
-describe('retry-request', function () {
-  var URI_404 = 'http://yahoo.com/theblahstore';
-  var URI_200 = 'http://yahoo.com/';
-  var URI_NON_EXISTENT = 'http://theblahstore';
+describe('retry-request', () => {
+  const URI_404 = 'http://yahoo.com/theblahstore';
+  const URI_200 = 'http://yahoo.com/';
+  const URI_NON_EXISTENT = 'http://theblahstore';
 
-  describe('streams', function () {
-    it('works with defaults in a stream', function (done) {
-      var responsesEmitted = 0;
+  describe('streams', () => {
+    it('works with defaults in a stream', done => {
+      let responsesEmitted = 0;
 
       retryRequest(URI_404)
         .on('error', done)
-        .on('response', function () {
+        .on('response', () => {
           responsesEmitted++;
         })
-        .on('complete', function () {
+        .on('complete', () => {
           assert.strictEqual(responsesEmitted, 1);
           done();
         });
     });
 
-    it('allows object mode', function () {
-      var retryStream = retryRequest(URI_404, { objectMode: true });
+    it('allows object mode', () => {
+      const retryStream = retryRequest(URI_404, {objectMode: true});
       assert.strictEqual(retryStream._readableState.objectMode, true);
     });
 
-    it('emits an error', function (done) {
-      retryRequest(URI_NON_EXISTENT)
-        .on('error', function () {
-          done();
-        });
+    it('emits an error', done => {
+      retryRequest(URI_NON_EXISTENT).on('error', () => {
+        done();
+      });
     });
 
-    it('emits a `request` event on each request', function (done) {
-      var requestsMade = 0;
-      var requestsEmitted = 0;
+    it('emits a `request` event on each request', done => {
+      let requestsMade = 0;
+      let requestsEmitted = 0;
 
-      var opts = {
-        shouldRetryFn: function() {
+      const opts = {
+        shouldRetryFn: function () {
           return requestsMade < 3;
         },
         request: function () {
-          var fakeRequestStream = new PassThrough();
+          const fakeRequestStream = new PassThrough();
 
           requestsMade++;
 
-          setImmediate(function () {
-            fakeRequestStream.emit('response', { statusCode: 200 });
+          setImmediate(() => {
+            fakeRequestStream.emit('response', {statusCode: 200});
 
             if (requestsMade === 3) {
-              setImmediate(function () {
+              setImmediate(() => {
                 fakeRequestStream.emit('complete');
               });
             }
           });
 
           return fakeRequestStream;
-        }
+        },
       };
 
       retryRequest(URI_404, opts)
-        .on('request', function() {
+        .on('request', () => {
           requestsEmitted++;
         })
         .on('error', done)
-        .on('complete', function () {
+        .on('complete', () => {
           assert.strictEqual(requestsEmitted, 3);
           done();
         });
     });
 
-    it('exposes an `abort` function to match request', function (done) {
-      var retryStream = retryRequest(URI_NON_EXISTENT);
+    it('exposes an `abort` function to match request', done => {
+      const retryStream = retryRequest(URI_NON_EXISTENT);
 
-      retryStream.on('error', function () {
+      retryStream.on('error', () => {
         assert.equal(typeof retryStream.abort, 'function');
         done();
       });
     });
 
-    it('works on the last attempt', function (done) {
-      var numAborts = 0;
-      var numAttempts = 0;
+    it('works on the last attempt', done => {
+      let numAborts = 0;
+      let numAttempts = 0;
 
-      var opts = {
+      const opts = {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = new PassThrough();
+          const fakeRequestStream = new PassThrough();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
 
-          var shouldReturnError = numAttempts < 3;
-          var response = shouldReturnError ? { statusCode: 503 } : { statusCode: 200 };
+          const shouldReturnError = numAttempts < 3;
+          const response = shouldReturnError
+            ? {statusCode: 503}
+            : {statusCode: 200};
 
-          setImmediate(function () {
+          setImmediate(() => {
             fakeRequestStream.emit('response', response);
 
             if (shouldReturnError) {
               return;
             }
 
-            setImmediate(function () {
+            setImmediate(() => {
               fakeRequestStream.emit('complete', numAttempts);
             });
           });
 
           return fakeRequestStream;
-        }
+        },
       };
 
       retryRequest(URI_404, opts)
         .on('error', done)
-        .on('complete', function (numAttempts) {
+        .on('complete', numAttempts => {
           assert.strictEqual(numAborts, 2);
           assert.deepEqual(numAttempts, 3);
           done();
         });
     });
 
-    it('never succeeds', function (done) {
-      var numAborts = 0;
-      var numAttempts = 0;
+    it('never succeeds', done => {
+      let numAborts = 0;
+      let numAttempts = 0;
 
-      var opts = {
+      const opts = {
         request: function () {
           numAttempts++;
 
-          var fakeRequestStream = new PassThrough();
+          const fakeRequestStream = new PassThrough();
           fakeRequestStream.abort = function () {
             numAborts++;
           };
 
-          var response = { statusCode: 503 };
-          setImmediate(function () {
+          const response = {statusCode: 503};
+          setImmediate(() => {
             fakeRequestStream.emit('response', response);
           });
 
           return fakeRequestStream;
-        }
+        },
       };
 
       retryRequest(URI_404, opts)
-        .on('response', function () {
+        .on('response', () => {
           assert.strictEqual(numAborts, 2);
           assert.strictEqual(numAttempts, 3);
           done();
@@ -158,284 +160,291 @@ describe('retry-request', function () {
         .on('error', done);
     });
 
-    it('forwards a request error', function (done) {
-      var error = new Error('Error.');
+    it('forwards a request error', done => {
+      const error = new Error('Error.');
 
-      var opts = {
+      const opts = {
         request: function () {
-          var fakeRequestStream = new PassThrough();
+          const fakeRequestStream = new PassThrough();
 
-          setImmediate(function () {
+          setImmediate(() => {
             fakeRequestStream.emit('response', {
-              statusCode: 200
+              statusCode: 200,
             });
 
-            setImmediate(function () {
+            setImmediate(() => {
               fakeRequestStream.destroy(error);
             });
           });
 
           return fakeRequestStream;
-        }
+        },
       };
 
-      retryRequest(URI_200, opts)
-        .on('error', function(err) {
-          assert.strictEqual(err, error);
-          done();
-        });
+      retryRequest(URI_200, opts).on('error', err => {
+        assert.strictEqual(err, error);
+        done();
+      });
     });
   });
 
-  describe('callbacks', function () {
-    it('works with defaults with a callback', function (done) {
-      retryRequest(URI_404, function () {
+  describe('callbacks', () => {
+    it('works with defaults with a callback', done => {
+      retryRequest(URI_404, () => {
         done();
       });
     });
 
-    it('exposes an `abort` function', function (done) {
-      var opts = {
+    it('exposes an `abort` function', done => {
+      const opts = {
         request: function () {
           return {
-            abort: done
+            abort: done,
           };
-        }
+        },
       };
 
-      var request = retryRequest(URI_200, opts, assert.ifError);
+      const request = retryRequest(URI_200, opts, assert.ifError);
       request.abort();
     });
 
-    it('returns an error', function (done) {
-      retryRequest(URI_NON_EXISTENT, function (err) {
+    it('returns an error', done => {
+      retryRequest(URI_NON_EXISTENT, err => {
         assert.equal(typeof err, 'object');
         done();
       });
     });
   });
 
-  describe('overriding', function () {
-    it('should ignore undefined options', function (done) {
-      var numAttempts = 0;
-      var error = new Error('ENOTFOUND');
+  describe('overriding', () => {
+    it('should ignore undefined options', done => {
+      let numAttempts = 0;
+      const error = new Error('ENOTFOUND');
 
-      var opts = {
+      const opts = {
         noResponseRetries: undefined,
         request: function (_, callback) {
           numAttempts++;
           callback(error);
-        }
+        },
       };
 
-      retryRequest(URI_NON_EXISTENT, opts, function (err) {
+      retryRequest(URI_NON_EXISTENT, opts, err => {
         assert.strictEqual(numAttempts, 3);
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should allow overriding retries', function (done) {
-      var opts = { retries: 0 };
+    it('should allow overriding retries', done => {
+      const opts = {retries: 0};
 
-      retryRequest(URI_404, opts, function () {
+      retryRequest(URI_404, opts, () => {
         done();
       });
     });
 
-    it('should use default noResponseRetries', function (done) {
-      var numAttempts = 0;
-      var error = new Error('ENOTFOUND');
+    it('should use default noResponseRetries', done => {
+      let numAttempts = 0;
+      const error = new Error('ENOTFOUND');
 
-      var opts = {
+      const opts = {
         request: function (_, callback) {
           numAttempts++;
           callback(error);
-        }
+        },
       };
 
-      retryRequest(URI_NON_EXISTENT, opts, function (err) {
+      retryRequest(URI_NON_EXISTENT, opts, err => {
         assert.strictEqual(numAttempts, 3);
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should allow overriding noResponseRetries', function (done) {
-      var numAttempts = 0;
-      var error = new Error('ENOTFOUND');
+    it('should allow overriding noResponseRetries', done => {
+      let numAttempts = 0;
+      const error = new Error('ENOTFOUND');
 
-      var opts = {
+      const opts = {
         noResponseRetries: 0,
         request: function (_, callback) {
           numAttempts++;
           callback(error);
-        }
+        },
       };
 
-      retryRequest(URI_NON_EXISTENT, opts, function (err) {
+      retryRequest(URI_NON_EXISTENT, opts, err => {
         assert.strictEqual(numAttempts, 1);
         assert.strictEqual(err, error);
         done();
       });
     });
 
-    it('should allow overriding currentRetryAttempt', function (done) {
-      var numAttempts = 0;
-      var opts = {
+    it('should allow overriding currentRetryAttempt', done => {
+      let numAttempts = 0;
+      const opts = {
         currentRetryAttempt: 1,
         request: function (_, responseHandler) {
           numAttempts++;
-          responseHandler(null, { statusCode: 500 });
-        }
+          responseHandler(null, {statusCode: 500});
+        },
       };
 
-      retryRequest(URI_404, opts, function (err) {
+      retryRequest(URI_404, opts, () => {
         assert.strictEqual(numAttempts, 1);
         done();
       });
     });
 
-    it('should allow overriding shouldRetryFn', function (done) {
-      var shouldRetryFnCalled = false;
+    it('should allow overriding shouldRetryFn', done => {
+      let shouldRetryFnCalled = false;
 
-      var opts = {
+      const opts = {
         retries: 1, // so that our retry function is only called once
 
         shouldRetryFn: function () {
           shouldRetryFnCalled = true;
           return true;
-        }
+        },
       };
 
-      retryRequest(URI_404, opts, function () {
+      retryRequest(URI_404, opts, () => {
         assert.strictEqual(shouldRetryFnCalled, true);
         done();
       });
     });
 
-    it('should allow overriding request', function (done) {
-      var opts = {
+    it('should allow overriding request', done => {
+      const opts = {
         request: function () {
           done();
-        }
+        },
       };
 
-      retryRequest(URI_200, opts, function () {});
+      retryRequest(URI_200, opts, () => {});
     });
   });
 
-  describe('shouldRetryFn', function () {
-    var URI = 'http://';
+  describe('shouldRetryFn', () => {
+    const URI = 'http://';
 
     function assertRetried(statusCode, callback) {
-      var initialRequestMade = false;
+      let initialRequestMade = false;
 
-      retryRequest(URI, {
-        request: function (_, responseHandler) {
-          if (initialRequestMade) {
-            // This is a retry attempt. "Test passed"
-            callback();
-            return;
-          }
+      retryRequest(
+        URI,
+        {
+          request: function (_, responseHandler) {
+            if (initialRequestMade) {
+              // This is a retry attempt. "Test passed"
+              callback();
+              return;
+            }
 
-          initialRequestMade = true;
-          responseHandler(null, { statusCode: statusCode });
-        }
-      }, assert.ifError);
+            initialRequestMade = true;
+            responseHandler(null, {statusCode: statusCode});
+          },
+        },
+        assert.ifError
+      );
     }
 
     function assertNotRetried(statusCode, callback) {
-      var initialRequestMade = false;
-      var requestWasRetried = false;
+      let initialRequestMade = false;
+      let requestWasRetried = false;
 
-      retryRequest(URI, {
-        request: function (_, responseHandler) {
-          requestWasRetried = initialRequestMade;
-          initialRequestMade = true;
-          responseHandler(null, { statusCode: statusCode });
-        }
-      }, function (err) {
-        if (err) {
-          callback(err);
-          return;
-        }
+      retryRequest(
+        URI,
+        {
+          request: function (_, responseHandler) {
+            requestWasRetried = initialRequestMade;
+            initialRequestMade = true;
+            responseHandler(null, {statusCode: statusCode});
+          },
+        },
+        err => {
+          if (err) {
+            callback(err);
+            return;
+          }
 
-        if (requestWasRetried) {
-          callback(new Error('Request was retried'));
-          return;
-        }
+          if (requestWasRetried) {
+            callback(new Error('Request was retried'));
+            return;
+          }
 
-        callback();
-      });
+          callback();
+        }
+      );
     }
 
-    it('should retry a 1xx code', function (done) {
+    it('should retry a 1xx code', done => {
       async.each(range(100, 199), assertRetried, done);
     });
 
-    it('should not retry a 2xx code', function (done) {
+    it('should not retry a 2xx code', done => {
       async.each(range(200, 299), assertNotRetried, done);
     });
 
-    it('should not retry a 3xx code', function (done) {
+    it('should not retry a 3xx code', done => {
       async.each(range(300, 399), assertNotRetried, done);
     });
 
-    it('should not retry a 4xx code', function (done) {
-      var statusCodes = range(400, 428).concat(range(430, 499));
+    it('should not retry a 4xx code', done => {
+      const statusCodes = range(400, 428).concat(range(430, 499));
 
       async.each(statusCodes, assertNotRetried, done);
     });
 
-    it('should retry a 429 code', function (done) {
+    it('should retry a 429 code', done => {
       assertRetried(429, done);
     });
 
-    it('should retry a 5xx code', function (done) {
+    it('should retry a 5xx code', done => {
       async.each(range(500, 599), assertRetried, done);
     });
   });
 
-  it('should not do any retries if unnecessary', function (done) {
-    var shouldRetryFnTimesCalled = 0;
+  it('should not do any retries if unnecessary', done => {
+    let shouldRetryFnTimesCalled = 0;
 
-    var opts = {
+    const opts = {
       shouldRetryFn: function () {
         shouldRetryFnTimesCalled++;
         return false;
-      }
+      },
     };
 
-    retryRequest(URI_200, opts, function () {
+    retryRequest(URI_200, opts, () => {
       assert.strictEqual(shouldRetryFnTimesCalled, 1);
       done();
     });
   });
 
-  it('has an initial delay when currentRetryAttempt > 0', function (done) {
-    var startTime = new Date();
+  it('has an initial delay when currentRetryAttempt > 0', done => {
+    const startTime = new Date();
 
-    var opts = {
+    const opts = {
       currentRetryAttempt: 1,
       request: function (_, responseHandler) {
-        responseHandler(null, { statusCode: 200 });
-      }
+        responseHandler(null, {statusCode: 200});
+      },
     };
 
-    retryRequest(URI_200, opts, function () {
-      var totalTime = new Date() - startTime;
+    retryRequest(URI_200, opts, () => {
+      const totalTime = new Date() - startTime;
       assert(totalTime >= 2000 && totalTime < 3000);
       done();
     });
   });
 });
 
-describe('getNextRetryDelay', function () {
-  var maxRetryDelay = 64;
-  var retryDelayMultiplier = 2;
-  var timeOfFirstRequest;
-  var totalTimeout = 64;
+describe('getNextRetryDelay', () => {
+  const maxRetryDelay = 64;
+  const retryDelayMultiplier = 2;
+  let timeOfFirstRequest;
+  const totalTimeout = 64;
 
   function secondsToMs(seconds) {
     return seconds * 1000;
@@ -445,14 +454,14 @@ describe('getNextRetryDelay', function () {
     timeOfFirstRequest = Date.now();
   });
 
-  it('should return exponential retry delay', function () {
+  it('should return exponential retry delay', () => {
     [1, 2, 3, 4, 5].forEach(assertTime);
 
     function assertTime(retryNumber) {
-      var min = (Math.pow(2, retryNumber) * secondsToMs(1));
-      var max = (Math.pow(2, retryNumber) * secondsToMs(1)) + secondsToMs(1);
+      const min = Math.pow(2, retryNumber) * secondsToMs(1);
+      const max = Math.pow(2, retryNumber) * secondsToMs(1) + secondsToMs(1);
 
-      var delay = retryRequest.getNextRetryDelay({
+      const delay = retryRequest.getNextRetryDelay({
         maxRetryDelay,
         retryDelayMultiplier,
         retryNumber,
@@ -464,14 +473,14 @@ describe('getNextRetryDelay', function () {
     }
   });
 
-  it('should allow overriding the multiplier', function () {
+  it('should allow overriding the multiplier', () => {
     [1, 2, 3, 4, 5].forEach(assertTime);
 
     function assertTime(multiplier) {
-      var min = (Math.pow(multiplier, 1) * secondsToMs(1));
-      var max = (Math.pow(multiplier, 1) * secondsToMs(1)) + secondsToMs(1);
+      const min = Math.pow(multiplier, 1) * secondsToMs(1);
+      const max = Math.pow(multiplier, 1) * secondsToMs(1) + secondsToMs(1);
 
-      var delay = retryRequest.getNextRetryDelay({
+      const delay = retryRequest.getNextRetryDelay({
         maxRetryDelay,
         retryDelayMultiplier: multiplier,
         retryNumber: 1,
@@ -483,7 +492,7 @@ describe('getNextRetryDelay', function () {
     }
   });
 
-  it('should honor total timeout setting', function () {
+  it('should honor total timeout setting', () => {
     // This test passes settings to calculate an enormous retry delay, if it
     // weren't for the timeout restrictions imposed by `totalTimeout`.
     // So, even though this is pretending to be the 10th retry, and our
@@ -492,8 +501,8 @@ describe('getNextRetryDelay', function () {
     // We tell the function that we have already been trying this request for
     // 30 seconds, and we will only wait a maximum of 60 seconds. Therefore, we
     // should end up with a retry delay of around 30 seconds.
-    var retryDelay = retryRequest.getNextRetryDelay({
-      // Allow 60 seconds maximum delay, 
+    const retryDelay = retryRequest.getNextRetryDelay({
+      // Allow 60 seconds maximum delay,
       timeOfFirstRequest: Date.now() - secondsToMs(30), // 30 seconds ago.
       totalTimeout: 60,
 
@@ -503,13 +512,13 @@ describe('getNextRetryDelay', function () {
       retryNumber: 10,
     });
 
-    var min = retryDelay - 10;
-    var max = retryDelay + 10;
+    const min = retryDelay - 10;
+    const max = retryDelay + 10;
     assert(retryDelay >= min && retryDelay <= max);
   });
 
-  it('should return maxRetryDelay if calculated retry would be too high', function () {
-    var delayWithoutLowMaxRetryDelay = retryRequest.getNextRetryDelay({
+  it('should return maxRetryDelay if calculated retry would be too high', () => {
+    const delayWithoutLowMaxRetryDelay = retryRequest.getNextRetryDelay({
       maxRetryDelay,
       retryDelayMultiplier,
       retryNumber: 100,
@@ -517,19 +526,24 @@ describe('getNextRetryDelay', function () {
       totalTimeout,
     });
 
-    var maxRetryDelayMs = secondsToMs(maxRetryDelay);
-    var min = maxRetryDelayMs - 10;
-    var max = maxRetryDelayMs + 10;
-    assert(delayWithoutLowMaxRetryDelay >= min && delayWithoutLowMaxRetryDelay <= max);
+    const maxRetryDelayMs = secondsToMs(maxRetryDelay);
+    const min = maxRetryDelayMs - 10;
+    const max = maxRetryDelayMs + 10;
+    assert(
+      delayWithoutLowMaxRetryDelay >= min && delayWithoutLowMaxRetryDelay <= max
+    );
 
-    var lowMaxRetryDelay = 1;
-    var delayWithLowMaxRetryDelay = retryRequest.getNextRetryDelay({
+    const lowMaxRetryDelay = 1;
+    const delayWithLowMaxRetryDelay = retryRequest.getNextRetryDelay({
       maxRetryDelay: lowMaxRetryDelay,
       retryDelayMultiplier,
       retryNumber: 100,
       timeOfFirstRequest,
       totalTimeout,
     });
-    assert.strictEqual(delayWithLowMaxRetryDelay, secondsToMs(lowMaxRetryDelay));
+    assert.strictEqual(
+      delayWithLowMaxRetryDelay,
+      secondsToMs(lowMaxRetryDelay)
+    );
   });
 });


### PR DESCRIPTION
The `node/no-unpublished-require` and `node/no-unpublished-import` errors are for the optional sibling package `request` library which is the default transport.

Fixes #47