### PR TITLE
fix: types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,16 @@ declare module 'retry-request' {
   import * as request from 'request';
   import * as teenyRequest from 'teeny-request';
 
+  type teenyRequestFunction = typeof teenyRequest extends Function
+    ? typeof teenyRequest
+    : never;
+
   namespace retryRequest {
-    defaults = retryRequest.Options;
+    const defaults: retryRequest.Options;
     function getNextRetryDelay(retryNumber: number): void;
     interface Options {
       objectMode?: boolean;
-      request: typeof request | typeof teenyRequest;
+      request: typeof request | teenyRequestFunction;
       retries?: number;
       noResponseRetries?: number;
       currentRetryAttempt?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,14 @@ declare module 'retry-request' {
     : never;
 
   namespace retryRequest {
+    /**
+     * Set the defaults for `retryRequest`.
+     */
     const defaults: retryRequest.Options;
-    function getNextRetryDelay(retryNumber: number): void;
+    /**
+     * Determines the next retry based on the provided configuration.
+     */
+    function getNextRetryDelay(config: Options): number;
     interface Options {
       objectMode?: boolean;
       request: typeof request | teenyRequestFunction;


### PR DESCRIPTION
Used `npm link` to verify in `nodejs-storage` (as TypeScript itself isn't available in this library). 🦕
