### PR TITLE
fix: get rid of debug runtime dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,19 @@
 'use strict';
 
 const {PassThrough} = require('stream');
-const debug = require('debug')('retry-request');
 const extend = require('extend');
+
+let debug = () => {};
+if (
+  typeof process !== 'undefined' &&
+  'env' in process &&
+  typeof process.env === 'object' &&
+  process.env.DEBUG === 'retry-request'
+) {
+  debug = message => {
+    console.log('retry-request:', message);
+  };
+}
 
 const DEFAULTS = {
   objectMode: false,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@types/request": "^2.48.8",
-    "debug": "^4.1.1",
     "extend": "^3.0.2",
     "teeny-request": "^9.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ request(urlThatReturns503)
 
 ## Can I monitor what retry-request is doing internally?
 
-Yes! This project uses [debug](https://www.npmjs.com/package/debug) to provide the current retry attempt, each response status, and the delay computed until the next retry attempt is made. To enable the debug mode, set the environment variable `DEBUG` to _retry-request_.
+Yes! To enable the debug mode, set the environment variable `DEBUG` to _retry-request_.
 
 (Thanks for the implementation, @yihaozhadan!)
 


### PR DESCRIPTION
`debug` has a reported vulnerability and there is no real need to have it as a dependency.