### PR TITLE
fix: move `@types/request` to dev dependencies and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "teeny-request": "^10.0.0"
   },
   "devDependencies": {
-    "@types/request": "^2.48.12",
+    "@types/request": "^2.48.13",
     "async": "^3.2.6",
     "gts": "^6.0.2",
     "jsdoc": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@types/request": "^2.48.12",
     "extend": "^3.0.2",
     "teeny-request": "^10.0.0"
   },
   "devDependencies": {
+    "@types/request": "^2.48.12",
     "async": "^3.2.6",
     "gts": "^6.0.2",
     "jsdoc": "^4.0.4",


### PR DESCRIPTION
Fixes https://github.com/googleapis/retry-request/issues/136.

This is an issue because this package has a dependency that has a [security vulnerability](https://github.com/form-data/form-data/security/advisories/GHSA-fjxv-7rqg-78g4).

A fix for the vulnerability warning was made [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73317).