### PR TITLE
Move @types/request to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@types/request": "^2.48.13",
     "extend": "^3.0.2",
     "teeny-request": "^10.0.0"
   },
   "devDependencies": {
+    "@types/request": "^2.48.13",
     "async": "^3.2.6",
     "gts": "^6.0.2",
     "jsdoc": "^4.0.4",


### PR DESCRIPTION
`@types/request` is installed as a normal dependency, while generally types are installed as devDependencies.

This was closed - but the move actually did not happen - https://github.com/googleapis/retry-request/issues/136 - I think accidental with other maintenance.

PR https://github.com/googleapis/retry-request/pull/149 also did this, but also updated the version, which was maybe not ideal at once.